### PR TITLE
add baconjs as peer and dev dependency instead of dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,7 +1011,8 @@
     "baconjs": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-1.0.0.tgz",
-      "integrity": "sha512-xtPIez7j0xW6Z8qbNcXo5Q/rVNmmdlUhS5GkNj3DlZsutKsdQL4d0L9mqoy34pWMLKXQKEihQfhEDx6bdieiCA=="
+      "integrity": "sha512-xtPIez7j0xW6Z8qbNcXo5Q/rVNmmdlUhS5GkNj3DlZsutKsdQL4d0L9mqoy34pWMLKXQKEihQfhEDx6bdieiCA==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
     "babel-register": "^6.26.0",
+    "baconjs": ">0.7 <2.0",
     "codecov": "^2.3.0",
     "eslint": "^4.6.1",
     "eslint-plugin-babel": "^4.1.2",
@@ -58,7 +59,9 @@
   },
   "dependencies": {
     "infestines": "^0.4.4",
-    "baconjs": ">0.7 <2.0",
     "react": "^15.0.1"
+  },
+  "peerDependencies": {
+    "baconjs": ">0.7 <2.0"
   }
 }


### PR DESCRIPTION
There is a problem with the version `1.0.6` of baret, where baconjs is specified as a dependency with semver of `>0.7 <2.0`. Updating baret to 1.0.6 in a project that has for example `baconjs@0.7.95` as dependency, the following happens:

```
# npm i
test@0.1.5 /Users/reko/Projects/test
└─┬ baret@1.0.6
  └── baconjs@1.0.0
```

And this breaks baret completely, as baret will import a different version of baconjs, and all these checks will fail: `const isObs = x => x instanceof Observable`, since the Observable symbol is from different package.

The root issue is that `baconjs` is also updated in the `package-lock.json` and has version of `1.0.0` there, and this version will be installed in all projects that depend on baret.

Baret should specify baconjs as a peer dependency instead of dependency, which ensures that baret will always use the same instance of baconjs as the parent package has installed. In addition baret is also added as a dev dependancy so that bacon is still installed when developing baret.

After making it a peer dependency, things work as expected:

```
#npm i
test@0.1.5 /Users/reko/Projects/test
└── baret@1.0.6
```